### PR TITLE
Added function ph_ref().

### DIFF
--- a/eNMRpy/Measurement/base.py
+++ b/eNMRpy/Measurement/base.py
@@ -91,7 +91,7 @@ class Measurement(object):
         '''
         ref_orig_ph = self.eNMRraw[ref]
         
-        for i in filter(lambda x: x[:2] =='ph', m.eNMRraw.keys()):
+        for i in filter(lambda x: x[:2] =='ph', self.eNMRraw.keys()):
             phase_name = 'ph' + str(i)
             self.eNMRraw[phase_name] = self.eNMRraw[phase_name] - ref_orig_ph
     

--- a/eNMRpy/Measurement/base.py
+++ b/eNMRpy/Measurement/base.py
@@ -92,8 +92,7 @@ class Measurement(object):
         ref_orig_ph = self.eNMRraw[ref]
         
         for i in filter(lambda x: x[:2] =='ph', self.eNMRraw.keys()):
-            phase_name = 'ph' + str(i)
-            self.eNMRraw[phase_name] = self.eNMRraw[phase_name] - ref_orig_ph
+            self.eNMRraw[i] = self.eNMRraw[i] - ref_orig_ph
     
     
     def comment(self, s, append_to_title=False):

--- a/eNMRpy/Measurement/base.py
+++ b/eNMRpy/Measurement/base.py
@@ -83,7 +83,19 @@ class Measurement(object):
         #self.dependency = None
 
         # END __INIT__
+    
+    def ph_ref(self, ref):
+        '''
+        reference your phase shifts on the shifts of one peak.
+        ref: string, name of the peak which phase is used for reference (usually solvent).
+        '''
+        ref_orig_ph = self.eNMRraw[ref]
         
+        for i in range (int((self.eNMRraw.shape[1] - 7)/8)):
+            phase_name = 'ph' + str(i)
+            self.eNMRraw[phase_name] = self.eNMRraw[phase_name] - ref_orig_ph
+    
+    
     def comment(self, s, append_to_title=False):
         '''
         write a comment as a multi-line-string or normal string

--- a/eNMRpy/Measurement/base.py
+++ b/eNMRpy/Measurement/base.py
@@ -91,7 +91,7 @@ class Measurement(object):
         '''
         ref_orig_ph = self.eNMRraw[ref]
         
-        for i in range (int((self.eNMRraw.shape[1] - 7)/8)):
+        for i in filter(lambda x: x[:2] =='ph', m.eNMRraw.keys()):
             phase_name = 'ph' + str(i)
             self.eNMRraw[phase_name] = self.eNMRraw[phase_name] - ref_orig_ph
     


### PR DESCRIPTION
References the phase shifts of all peaks to this specific peak phase shifts. Useful for systems with non-interacting solvents to remove convection artifacts.