### PR TITLE
Update base.py

### DIFF
--- a/eNMRpy/Measurement/base.py
+++ b/eNMRpy/Measurement/base.py
@@ -172,7 +172,7 @@ class Measurement(object):
         self.data_orig = self.data
 
         if (xmin is not None) or (xmax is not None):
-            self.data = self.set_spectral_region(xmin=xmin, xmax=xmax, mode=cropmode)
+            self.set_spectral_region(xmin=xmin, xmax=xmax, mode=cropmode)
     
 
     def plot_fid(self, xmax=None, xmin=0, step=1):


### PR DESCRIPTION
self.data wurde zuvor von set_spectral_region überschrieben und zum tuple, da set_spectral_region zwei arrays returned. self.data und self.ppm.